### PR TITLE
DJにお試しのエフェクトを付与

### DIFF
--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -8,6 +8,21 @@ EditorUserSettings:
     RecentlyUsedScenePath-0:
       value: 22424703114646680e0b0227036c6c111b07142f1f2b233e2867083debf42d
       flags: 0
+    RecentlyUsedScenePath-1:
+      value: 224247031146466f0c05192f1905501c12120a651c2427291e2a183de7ae2136ebf32f
+      flags: 0
+    RecentlyUsedScenePath-2:
+      value: 224247031146465404050d35116c6f1c170e2b29292623707c67083debf42d
+      flags: 0
+    RecentlyUsedScenePath-3:
+      value: 224247031146465404050d35116c50191d160f2b133b2535232c5326ece92021
+      flags: 0
+    RecentlyUsedScenePath-4:
+      value: 224247031146466f0c05192f1905501c12120a651f2b233e283a5203eee12d0be1e238eca92f31352d1b
+      flags: 0
+    RecentlyUsedScenePath-5:
+      value: 224247031146465404050d35116c6f1c170e563f22213229
+      flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650
       flags: 0


### PR DESCRIPTION
DJの照明の明滅を盛り上がり度に合わせた演出を追加
posteffectの追加、ゲームウィンドウからの見え方が結構違います、確かめたければoiwaka/Scenes/Playにて見れます